### PR TITLE
put ntp server in conf

### DIFF
--- a/src/static/static/home/yi-hack-v4/etc/system.conf
+++ b/src/static/static/home/yi-hack-v4/etc/system.conf
@@ -9,4 +9,5 @@ REC_WITHOUT_CLOUD=no
 MQTT=no
 RTSP=no
 NTPD=no
+NTP_SERVER=pool.ntp.org
 

--- a/src/static/static/home/yi-hack-v4/script/system.sh
+++ b/src/static/static/home/yi-hack-v4/script/system.sh
@@ -63,7 +63,7 @@ fi
 
 if [[ $(get_config NTPD) == "yes" ]] ; then
     # Wait until all the other processes have been initialized
-    sleep 5 && ntpd -p pool.ntp.org &
+    sleep 5 && ntpd -p $(get_config NTP_SERVER) &
 fi
 
 if [[ $(get_config MQTT) == "yes" ]] ; then


### PR DESCRIPTION
to make it easier to change/override

I run a local ntp server, and although I _can_ edit system.sh to change, editing system.conf feels more correct.